### PR TITLE
Add methods to call API User Collections endpoints (thus also add Pri…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # go-wallhaven
 
-golang wrapper for the wallhaven.cc api
+golang wrapper for the wallhaven.cc api version 1
 
 ## Installation
 

--- a/search.go
+++ b/search.go
@@ -9,10 +9,10 @@ import (
 
 // Search Types
 
-//Category is an enum used to represent wallpaper categories
+// Category is an enum used to represent wallpaper categories
 type Category int
 
-//Enum for Category Types
+// Enum for Category Types
 const (
 	General Category = 0x100
 	Anime   Category = 0x010
@@ -23,10 +23,10 @@ func (c Category) String() string {
 	return strconv.FormatInt(int64(c), 2)
 }
 
-//Purity is an enum used to represent
+// Purity is an enum used to represent
 type Purity int
 
-//Enum for purity types
+// Enum for purity types
 const (
 	SFW     Purity = 0x100
 	Sketchy Purity = 0x010
@@ -37,10 +37,10 @@ func (p Purity) String() string {
 	return strconv.FormatInt(int64(p), 2)
 }
 
-//Sort enum specifies the various sort types accepted by WH api
+// Sort enum specifies the various sort types accepted by WH api
 type Sort int
 
-//Sort Enum Values
+// Sort Enum Values
 const (
 	DateAdded Sort = iota + 1
 	Relevance
@@ -55,10 +55,10 @@ func (s Sort) String() string {
 	return str[s]
 }
 
-//Order enum specifies the sort orders accepted by WH api
+// Order enum specifies the sort orders accepted by WH api
 type Order int
 
-//Sort Enum Values
+// Sort Enum Values
 const (
 	Desc Order = iota + 1
 	Asc
@@ -69,10 +69,24 @@ func (o Order) String() string {
 	return str[o]
 }
 
-//TopRange is used to specify the time window for 'top' result when topList is chosen as sort param
+// Privacy enum specifies the collection privacy returned by WH api
+type Privacy int
+
+// Privacy Enum Values
+const (
+	Private Privacy = iota
+	Public
+)
+
+func (p Privacy) String() string {
+	str := [...]string{"private", "public"}
+	return str[p]
+}
+
+// TopRange is used to specify the time window for 'top' result when topList is chosen as sort param
 type TopRange int
 
-//Enum for TopRange values
+// Enum for TopRange values
 const (
 	Day TopRange = iota + 1
 	ThreeDay
@@ -87,7 +101,7 @@ func (t TopRange) String() string {
 	return str[t]
 }
 
-//Resolution specifies the image resolution to find
+// Resolution specifies the image resolution to find
 type Resolution struct {
 	Width  int64
 	Height int64
@@ -101,7 +115,7 @@ func (r Resolution) isValid() bool {
 	return r.Width > 0 && r.Height > 0
 }
 
-//Ratio may be used to specify the aspect ratio of the search
+// Ratio may be used to specify the aspect ratio of the search
 type Ratio struct {
 	Horizontal int
 	Vertical   int
@@ -115,7 +129,7 @@ func (r Ratio) isValid() bool {
 	return r.Vertical > 0 && r.Horizontal > 0
 }
 
-//Q is used to hold the Q params for various fulltext options that the WH Search supports
+// Q is used to hold the Q params for various fulltext options that the WH Search supports
 type Q struct {
 	Tags       []string
 	ExcudeTags []string
@@ -151,7 +165,7 @@ func (q Q) toQuery() url.Values {
 	return out
 }
 
-//Search provides various parameters to search for on wallhaven
+// Search provides various parameters to search for on wallhaven
 type Search struct {
 	Query       Q
 	Categories  Category
@@ -217,12 +231,16 @@ func (s Search) toQuery() url.Values {
 	return v
 }
 
-//SearchWallpapers performs a search on WH given a set of criteria.
-//Note that this API behaves slightly differently than the various
-//single item apis as it also includes the metadata for paging purposes
+// SearchWallpapers performs a search on WH given a set of criteria.
+// Note that this API behaves slightly differently than the various
+// single item apis as it also includes the metadata for paging purposes
 func SearchWallpapers(search *Search) (*SearchResults, error) {
 
 	resp, err := getWithValues("/search/", search.toQuery())
+	if err != nil {
+		return nil, err
+	}
+
 	out := &SearchResults{}
 	err = processResponse(resp, out)
 	if err != nil {

--- a/structs.go
+++ b/structs.go
@@ -6,17 +6,20 @@ import (
 	"strconv"
 )
 
-//WallpaperID is a string representing a wallpaper
+// WallpaperID is a string representing a wallpaper
 type WallpaperID string
 
-//TagID is an int representing a tag on wh
+// TagID is an int representing a tag on wh
 type TagID int64
 
 func (t TagID) String() string {
 	return strconv.Itoa(int(t))
 }
 
-//Avatar user's avatar
+// CollectionID is a string representing a Collection
+type CollectionID string
+
+// Avatar user's avatar
 type Avatar struct {
 	Two00Px  string `json:"200px"`
 	One28Px  string `json:"128px"`
@@ -24,14 +27,14 @@ type Avatar struct {
 	Two0Px   string `json:"20px"`
 }
 
-//Uploader information on who uploaded a given wallpaper
+// Uploader information on who uploaded a given wallpaper
 type Uploader struct {
 	Username string `json:"username"`
 	Group    string `json:"group"`
 	Avatar   Avatar `json:"avatar"`
 }
 
-//Tag full data on a given wallpaper tag
+// Tag full data on a given wallpaper tag
 type Tag struct {
 	ID         int    `json:"id"`
 	Name       string `json:"name"`
@@ -42,7 +45,7 @@ type Tag struct {
 	CreatedAt  string `json:"created_at"`
 }
 
-//Wallpaper information about a given wallpaper
+// Wallpaper information about a given wallpaper
 type Wallpaper struct {
 	ID         WallpaperID `json:"id"`
 	URL        string      `json:"url"`
@@ -66,7 +69,7 @@ type Wallpaper struct {
 	Tags       []Tag       `json:"tags"`
 }
 
-//Download downloads a wallpaper given the local filepath to save the wallpaper to
+// Download downloads a wallpaper given the local filepath to save the wallpaper to
 func (w *Wallpaper) Download(dir string) error {
 	resp, err := getAuthedResponse(w.Path)
 	if err != nil {
@@ -76,7 +79,7 @@ func (w *Wallpaper) Download(dir string) error {
 	return download(path, resp)
 }
 
-//Thumbs paths for thumbnail images of wallpaper
+// Thumbs paths for thumbnail images of wallpaper
 type Thumbs struct {
 	Large    string `json:"large"`
 	Original string `json:"original"`
@@ -85,7 +88,7 @@ type Thumbs struct {
 
 //TODO: (dlasky) add download support for thumbs
 
-//Meta paging and stats metadata for search results
+// Meta paging and stats metadata for search results
 type Meta struct {
 	CurrentPage int         `json:"current_page"`
 	LastPage    int         `json:"last_page"`
@@ -94,7 +97,7 @@ type Meta struct {
 	Query       interface{} `json:"query"`
 }
 
-//User User preference Data (set on wallhaven's user GUI)
+// User User preference Data (set on wallhaven's user GUI)
 type User struct {
 	ThumbSize     string   `json:"thumb_size"`
 	PerPage       string   `json:"per_page"`
@@ -107,25 +110,44 @@ type User struct {
 	UserBlacklist []string `json:"user_blacklist"`
 }
 
+type Collection struct {
+	ID      CollectionID `json:"id"`
+	Label   string       `json:"label"`
+	Views   string       `json:"views"`
+	Privacy Privacy      `json:"public"`
+	Count   int          `json:"count"`
+}
+
 //Result Structs -- server responses
 
-//SearchResults a wrapper containing search results from wh
+// SearchResults a wrapper containing search results from wh
 type SearchResults struct {
 	Data []Wallpaper `json:"data"`
 	Meta Meta        `json:"meta"`
 }
 
-//TagResult a wrapper containing a single tag result when TagInfo is requested
+// TagResult a wrapper containing a single tag result when TagInfo is requested
 type TagResult struct {
 	Data Tag `json:"data"`
 }
 
-//UserResult a wrapper containing user preference data
+// UserResult a wrapper containing user preference data
 type UserResult struct {
 	Data User `json:"data"`
 }
 
-//WallpaperResult a wrapper containing a single wallpaper result when WallpaperInfo is requested
+// WallpaperResult a wrapper containing a single wallpaper result when WallpaperInfo is requested
 type WallpaperResult struct {
 	Data Wallpaper `json:"data"`
+}
+
+// CollectionsResult a wrapper containing an array of user's collection.
+type CollectionsResult struct {
+	Data []Collection `json:"data"`
+}
+
+// CollectionWallpapersResult a wrapper containing the list of wallpapers for a given user's collection and its Metadata.
+type CollectionWallpapersResult struct {
+	Data []Wallpaper `json:"data"`
+	Meta Meta        `json:"meta"`
 }

--- a/user.go
+++ b/user.go
@@ -1,11 +1,12 @@
 package wallhaven
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 )
 
-//GetUserSettings returns user preferences for the current logged in user. This method requires an API key
+// GetUserSettings returns user preferences for the current logged in user. This method requires an API key
 func GetUserSettings(apiKey string) (*User, error) {
 	u, _ := url.Parse(getWithBase("/settings"))
 	q := u.Query()
@@ -18,4 +19,43 @@ func GetUserSettings(apiKey string) (*User, error) {
 	info := &UserResult{}
 	processResponse(resp, info)
 	return &info.Data, nil
+}
+
+// GetUserCollections returns the user's collections. This method requires an API key
+// If NO username is provided (i.e: username == "") then this method will returns the authenticated user collections (public and private).
+// If one username is provided (i.e: username != "") then this method will only returns user PUBLIC collections
+func GetUserCollections(apiKey string, username string) (*[]Collection, error) {
+	var u *url.URL
+	if username == "" {
+		u, _ = url.Parse(getWithBase("/collections"))
+	} else {
+		u, _ = url.Parse(getWithBase("/collections/" + username))
+	}
+	q := u.Query()
+	q.Add("apiKey", apiKey)
+	u.RawQuery = q.Encode()
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+	collections := &CollectionsResult{}
+	processResponse(resp, collections)
+	return &collections.Data, nil
+}
+
+// GetUserCollectionWallpapers returns the Wallpapers as array from the user's collections. This method requires an API key.
+// Username is required.
+func GetUserCollectionWallpapers(apiKey string, username string, id CollectionID) (*[]Wallpaper, error) {
+	u, _ := url.Parse(getWithBase(fmt.Sprintf("%s/%s/%s", "/collections", username, id)))
+	q := u.Query()
+	q.Add("apiKey", apiKey)
+	u.RawQuery = q.Encode()
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+	wallpapers := &CollectionWallpapersResult{}
+	processResponse(resp, wallpapers)
+	return &wallpapers.Data, nil
+
 }

--- a/wallhaven.go
+++ b/wallhaven.go
@@ -1,2 +1,2 @@
-//Package wallhaven provides a wrapper around the wallhaven.cc alpha api. All methods are exposed and contain wrapper structs to make working with the results easier.
+// Package wallhaven provides a wrapper around the wallhaven.cc api V1. All methods are exposed and contain wrapper structs to make working with the results easier.
 package wallhaven


### PR DESCRIPTION
This Commit adds 2 missing methods to interact with [Wallhaven API User Collection](https://wallhaven.cc/help/api#user-settings):

- `GetUserCollections(apiKey string, username string) (*[]Collection, error)` which returns the list of collection for a given username. If no username is provided, the authenticated user (Private and Public) collections list will be returned. If the given is different than the authenticated user, only the user public collections list is returned.
-  `GetUserCollectionWallpapers(apiKey string, username string, id CollectionID) (*[]Wallpaper, error)` which returns the list of wallpaper for a given username and collection ID. The same Privacy rules apply as `GetUserCollections()` (i.e: username == authenticated user => Public/Private Collections, else only Public Collections).